### PR TITLE
fix: foreign key of photos

### DIFF
--- a/db/migrate/20240627015629_create_photos.rb
+++ b/db/migrate/20240627015629_create_photos.rb
@@ -6,8 +6,8 @@ class CreatePhotos < ActiveRecord::Migration[7.1]
       t.string :description
       t.boolean :is_private
       t.integer :number_like
-      t.belongs_to :user
-      t.belongs_to :album
+      t.belongs_to :user, foreign_key: true
+      t.belongs_to :album, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,4 +57,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_27_015629) do
   end
 
   add_foreign_key "albums", "users"
+  add_foreign_key "photos", "albums"
+  add_foreign_key "photos", "users"
 end


### PR DESCRIPTION
-Should put foreign_key: true at t.belongs_to. That makes database sync with your migration (it means in database, this table will have foreign_key)